### PR TITLE
Drop assertion plans.

### DIFF
--- a/test/console-format.js
+++ b/test/console-format.js
@@ -6,8 +6,6 @@ var characters = require('./fixtures/emoji-characters.js');
 var consoleFormat = require('../lib/console-format.js');
 
 test('consoleFormat emoji', t => {
-  t.plan(characters.length);
-
   characters.forEach(function (e) {
     var result = consoleFormat(`${e}:`);
 

--- a/test/emoji.parse-fail.js
+++ b/test/emoji.parse-fail.js
@@ -7,8 +7,6 @@ var emoji = require('../parsers/emoji.js');
 
 characters.forEach(function (e) {
   test('parse fail on emoji with non-emoji a' + e + 'a', function (t) {
-    t.plan(1);
-
     var result = emoji.parse(`a${e}a`);
 
     t.false(result);

--- a/test/emoji.parse-one.js
+++ b/test/emoji.parse-one.js
@@ -7,7 +7,6 @@ var emoji = require('../parsers/emoji.js');
 
 characters.forEach(function (e) {
   test('parse one emoji ' + e, function (t) {
-    t.plan(1);
     t.is(emoji.parse(e)[0], e);
   });
 });

--- a/test/emoji.parse-two.js
+++ b/test/emoji.parse-two.js
@@ -7,8 +7,6 @@ var emoji = require('../parsers/emoji.js');
 
 characters.forEach(function (e) {
   test('parse two emoji ' + e + e, function (t) {
-    t.plan(2);
-
     var result = emoji.parse(e + e);
 
     t.is(result[0], e);

--- a/test/filtering.js
+++ b/test/filtering.js
@@ -6,24 +6,17 @@ var characters = require('./fixtures/emoji-characters.js');
 var utilities = require('../emoji-aware.js');
 
 test('onlyEmoji fail broken string', t => {
-  t.plan(1);
-
   var result = utilities.onlyEmoji('\uDC00\uDC01');
-
   t.false(result);
 });
 
 test('withoutEmoji fail broken string', t => {
-  t.plan(1);
-
   var result = utilities.withoutEmoji('\uDC00\uDC01');
 
   t.false(result);
 });
 
 test('onlyEmoji', t => {
-  t.plan(characters.length);
-
   characters.forEach(function (e) {
     var result = utilities.onlyEmoji(`abcd${e}fg`);
 
@@ -32,8 +25,6 @@ test('onlyEmoji', t => {
 });
 
 test('withoutEmoji', t => {
-  t.plan(characters.length);
-
   characters.forEach(function (e) {
     var result = utilities.withoutEmoji(`abcd${e}fg`);
 

--- a/test/is-emoji.js
+++ b/test/is-emoji.js
@@ -8,14 +8,10 @@ var isEmoji = require('../lib/is-emoji.js');
 
 characters.forEach(function (e) {
   test('isEmoji emoji', function (t) {
-    t.plan(1);
-
     t.true(isEmoji(e));
   });
 });
 
 test('isEmoji fail on non-emoji', function (t) {
-  t.plan(1);
-
   t.false(isEmoji('a'));
 });

--- a/test/parse-one.js
+++ b/test/parse-one.js
@@ -7,13 +7,10 @@ var emoji = require('../parsers/emoji.js');
 
 characters.forEach(function (e) {
   test('parseOne emoji ' + e, function (t) {
-    t.plan(1);
     t.is(emoji.parseOne(e), e);
   });
 });
 
 test('parseOne fail non-emoji', function (t) {
-  t.plan(1);
-
   t.false(emoji.parseOne('a'));
 });

--- a/test/unicode.js
+++ b/test/unicode.js
@@ -6,8 +6,6 @@ var characters = require('./fixtures/emoji-characters.js');
 var unicode = require('../parsers/unicode-and-emoji.js');
 
 test('parseOne emoji', t => {
-  t.plan(characters.length);
-
   characters.forEach(function (e) {
     var result = unicode.parseOne(e);
 
@@ -16,8 +14,6 @@ test('parseOne emoji', t => {
 });
 
 test('parse string that includes emoji', t => {
-  t.plan(characters.length * 7);
-
   characters.forEach(function (e) {
     var result = unicode.parse(`abcd${e}fg`);
 
@@ -32,32 +28,24 @@ test('parse string that includes emoji', t => {
 });
 
 test('parse unicode string', t => {
-  t.plan(1);
-
   var result = unicode.parse('Testing «ταБЬℓσ»: 1<2 & 4+1>3, now 20% off!');
 
   t.is(result[0], 'T');
 });
 
 test('parseOne fail empty string', t => {
-  t.plan(1);
-
   var result = unicode.parseOne('');
 
   t.false(result);
 });
 
 test('parse empty string', t => {
-  t.plan(1);
-
   var result = unicode.parse('');
 
   t.same(result, []);
 });
 
 test('parse fail broken string', t => {
-  t.plan(1);
-
   var result = unicode.parse('\uDC00\uDC01');
 
   t.false(result);


### PR DESCRIPTION
Assertion plans aren't really necessary in synchronous tests.
They only become necessary in async tests with multiple callbacks where you what to guard against `t.end` being called before a deferred assertion.

Note: There is absolutely nothing wrong with using plans the way you are. They just slow down the tests a little. I'm using this library to benchmark AVA vs Mocha, and mocha doesn't offer plan tracking. So this is really just to ensure a fair comparison. There's no need to merge unless you really care about shaving off 0.5 seconds per test run.
